### PR TITLE
KNearest returns [] if k > the object count in the tree

### DIFF
--- a/quadtree.go
+++ b/quadtree.go
@@ -226,7 +226,11 @@ func (qt *QuadTree) knearest(a *AABB, i int, v map[*QuadTree]bool, fn filter) []
 		return results
 	}
 
-	return qt.parent.knearest(a, i, v, fn)
+	results = append(results, qt.parent.knearest(a, i, v, fn)...)
+	if len(results) >= i {
+		results = results[:i]
+	}
+	return results
 }
 
 // Insert will attempt to insert the point into the QuadTree. It will


### PR DESCRIPTION
Fix bug where the wrong knearest list is returned (most of the time empty) when k is bigger than the actual object count in the tree.
If we get to the last line in the knearest function, it just returns the result of the recursion instead of the nodes that were collected before plus the recursion result.